### PR TITLE
Quick fix for #2

### DIFF
--- a/nativetypes/native_float.py
+++ b/nativetypes/native_float.py
@@ -103,6 +103,9 @@ class nfloat(object):
     def __repr__(self):
         typename = type(self).__name__
         return '%s(%s)' % (typename, self)
+    def __format__(self, format_spec):
+        template = '{{:{}}}'.format(format_spec)
+        return template.format(self.v)
     def __int__(self):
         return int(float(self))
     def __bool__(self):

--- a/nativetypes/native_float.py
+++ b/nativetypes/native_float.py
@@ -105,7 +105,7 @@ class nfloat(object):
         return '%s(%s)' % (typename, self)
     def __format__(self, format_spec):
         template = '{{:{}}}'.format(format_spec)
-        return template.format(self.v)
+        return template.format(float(self))
     def __int__(self):
         return int(float(self))
     def __bool__(self):

--- a/nativetypes/native_int.py
+++ b/nativetypes/native_int.py
@@ -125,6 +125,9 @@ class nint(object):
     def __repr__(self):
         typename = type(self).__name__
         return '%s(%s)' % (typename, self)
+    def __format__(self, format_spec):
+        template = '{{:{}}}'.format(format_spec)
+        return template.format(self.v)
     def __int__(self):
         return int(self.v)
     def __bool__(self):

--- a/nativetypes/native_int.py
+++ b/nativetypes/native_int.py
@@ -127,7 +127,7 @@ class nint(object):
         return '%s(%s)' % (typename, self)
     def __format__(self, format_spec):
         template = '{{:{}}}'.format(format_spec)
-        return template.format(self.v)
+        return template.format(int(self))
     def __int__(self):
         return int(self.v)
     def __bool__(self):

--- a/tests/tests_nfloat.py
+++ b/tests/tests_nfloat.py
@@ -56,11 +56,11 @@ def test_nfloat_ops_type():
     assert repr(float64(inf)) == 'float64(inf)'
     # Format
     assert '{0}'.format(float32(-0.5)) == str(-0.5)
-    assert '{0}'.format(float32(-0.5)) == str(+0.0)
-    assert '{0}'.format(float32(-0.5)) == str(-1.0)
-    assert '{0}'.format(float32(-0.5)) == str(+1.0)
-    assert '{0}'.format(float32(-0.5)) == str(+inf)
-    assert '{0}'.format(float32(-0.5)) == str(+nan)
+    assert '{0}'.format(float32(+0.0)) == str(+0.0)
+    assert '{0}'.format(float32(-1.0)) == str(-1.0)
+    assert '{0}'.format(float32(+1.0)) == str(+1.0)
+    assert '{0}'.format(float32(+inf)) == str(+inf)
+    assert '{0}'.format(float32(+nan)) == str(+nan)
     # Integer
     assert int(float32(-0.5)) == int(-0.5)
     assert int(float32(-0.0)) == int(-0.0)

--- a/tests/tests_nfloat.py
+++ b/tests/tests_nfloat.py
@@ -54,6 +54,13 @@ def test_nfloat_ops_type():
     assert repr(float64(1.0)) == 'float64(1.0)'
     assert repr(float64(nan)) == 'float64(nan)'
     assert repr(float64(inf)) == 'float64(inf)'
+    # Format
+    assert '{0}'.format(float32(-0.5)) == str(-0.5)
+    assert '{0}'.format(float32(-0.5)) == str(+0.0)
+    assert '{0}'.format(float32(-0.5)) == str(-1.0)
+    assert '{0}'.format(float32(-0.5)) == str(+1.0)
+    assert '{0}'.format(float32(-0.5)) == str(+inf)
+    assert '{0}'.format(float32(-0.5)) == str(+nan)
     # Integer
     assert int(float32(-0.5)) == int(-0.5)
     assert int(float32(-0.0)) == int(-0.0)

--- a/tests/tests_nint.py
+++ b/tests/tests_nint.py
@@ -91,6 +91,12 @@ def test_nint_ops_type():
     # Representation
     assert repr(int8(123)) == 'int8(123)'
     assert repr(uint16(456)) == 'uint16(456)'
+    # Format
+    assert '{0}'.format(uint8(0x00)) == str(int8(0x00)) == str(0)
+    assert '{0}'.format(uint8(0x01)) == str(int8(0x01)) == str(1)
+    assert '{0}'.format(uint8(0x7F)) == str(int8(0x7F)) == str(127)
+    assert '{0}'.format(uint8(0xFF)) == str(255)
+    assert '{0}'.format(uint8(0xFF)) == str(-1)
     # Integer
     assert int(uint8(0x00)) == int(int8(0x00)) == 0
     assert int(uint8(0x01)) == int(int8(0x01)) == 1

--- a/tests/tests_nint.py
+++ b/tests/tests_nint.py
@@ -87,7 +87,7 @@ def test_nint_ops_type():
     assert str(uint8(0x01)) == str(int8(0x01)) == str(1)
     assert str(uint8(0x7F)) == str(int8(0x7F)) == str(127)
     assert str(uint8(0xFF)) == str(255)
-    assert str( int8(0xFF)) == str(-1)
+    assert str(int8(0xFF)) == str(-1)
     # Representation
     assert repr(int8(123)) == 'int8(123)'
     assert repr(uint16(456)) == 'uint16(456)'
@@ -96,7 +96,7 @@ def test_nint_ops_type():
     assert '{0}'.format(uint8(0x01)) == str(int8(0x01)) == str(1)
     assert '{0}'.format(uint8(0x7F)) == str(int8(0x7F)) == str(127)
     assert '{0}'.format(uint8(0xFF)) == str(255)
-    assert '{0}'.format(uint8(0xFF)) == str(-1)
+    assert '{0}'.format(int8(0xFF)) == str(-1)
     # Integer
     assert int(uint8(0x00)) == int(int8(0x00)) == 0
     assert int(uint8(0x01)) == int(int8(0x01)) == 1


### PR DESCRIPTION
I've done a (partially untested) fix for the issue #2. It *should* work, but it should be fully tested before merging. 

Now both `native_int` and `native_float` support the `format` method seamlessly.