### PR TITLE
Modulo the width when shifting integers by more than the width

### DIFF
--- a/nativetypes/native_int.py
+++ b/nativetypes/native_int.py
@@ -178,9 +178,9 @@ class nint(object):
     def __xor__(self, rhs):
         return op_binary(self, rhs, operator.__xor__)
     def __lshift__(self, rhs):
-        return op_binary(self, rhs, operator.__lshift__)
+        return op_binary(self, rhs % self.b, operator.__lshift__)
     def __rshift__(self, rhs):
-        return op_binary(self, rhs, operator.__rshift__)
+        return op_binary(self, rhs % self.b, operator.__rshift__)
 
     # Reflected binary operation
     def __radd__(self, lhs):
@@ -206,9 +206,9 @@ class nint(object):
     def __rxor__(self, lhs):
         return op_binary(lhs, self, operator.__xor__)
     def __rlshift__(self, lhs):
-        return op_binary(lhs, self, operator.__lshift__)
+        return op_binary(lhs, self % self.b, operator.__lshift__)
     def __rrshift__(self, lhs):
-        return op_binary(lhs, self, operator.__rshift__)
+        return op_binary(lhs, self % self.b, operator.__rshift__)
 
     # In-place operations
     def __iadd__(self, v):
@@ -234,9 +234,9 @@ class nint(object):
     def __ixor__(self, v):
         return self.op_binary_inplace(v, operator.__xor__)
     def __ilshift__(self, v):
-        return self.op_binary_inplace(v, operator.__lshift__)
+        return self.op_binary_inplace(v % self.b, operator.__lshift__)
     def __irshift__(self, v):
-        return self.op_binary_inplace(v, operator.__rshift__)
+        return self.op_binary_inplace(v % self.b, operator.__rshift__)
 
     # Boolean operations
     def __eq__(self, rhs):

--- a/tests/tests_nint.py
+++ b/tests/tests_nint.py
@@ -191,6 +191,8 @@ def test_nint_ops_binary():
     # Shifts
     assert uint16(0x1234) >> 4 == uint16(0x0123)
     assert uint16(0x1234) << 4 == uint16(0x2340)
+    assert uint16(0x1234) >> 20 == uint16(0x0123)
+    assert uint16(0x1234) << 20 == uint16(0x2340)
 
 def test_nint_ops_reflected():
     # Signedness (int + nint)
@@ -221,6 +223,8 @@ def test_nint_ops_reflected():
     # Shifts
     assert 0x1234 >> uint16(4) == uint16(0x0123)
     assert 0x1234 << uint16(4) == uint16(0x2340)
+    assert 0x1234 >> uint16(20) == uint16(0x0123)
+    assert 0x1234 << uint16(20) == uint16(0x2340)
 
 def test_nint_ops_inplace():
     # Casts
@@ -250,6 +254,8 @@ def test_nint_ops_inplace():
     # Shifts
     v = uint16(0x1234);  v >>= 4;  assert v == uint16(0x0123)
     v = uint16(0x1234);  v <<= 4;  assert v == uint16(0x2340)
+    v = uint16(0x1234);  v >>= 20;  assert v == uint16(0x0123)
+    v = uint16(0x1234);  v <<= 20;  assert v == uint16(0x2340)
 
 def test_nint_ops_relational():
     # Casts


### PR DESCRIPTION
On x86, when shifting an integer by more than its width, the shift amount will be treated modulo the width. However, Native Types will treat the shift amount as is, and thus leads to an inconsistent result. For example:

[C/C++ & GCC/MSVC & no optimization on x86](https://godbolt.org/z/P3be435xv):
```c
#include <stdio.h>

int main() {
    int n = 33;
    printf("%d", 1 << n);  // 2
}
```

Native Types:
```python
from nativetypes import *

print(int32(1) << 33)  # 0
```

Although shifting an integer by more than its width is undefined behavior in C/C++, I believe following x86‘s behavior would be more valuable for reverse engineering. Is it possible for you to accept this change?
